### PR TITLE
Clean content before gsub().

### DIFF
--- a/src/bsfilter.rb
+++ b/src/bsfilter.rb
@@ -1255,6 +1255,7 @@ EOM
             ''
           end
         end
+        content = NKF.nkf('-e -X -Z0 -m0', content);
         content = NKF.nkf('-e -X -Z0', content.gsub(/\?(iso-2202-jp|shift-jis)\?/i, '?ISO-2022-JP?'))
       else
         content = latin2ascii(content)


### PR DESCRIPTION
とあるメールでbsfilterが死んでしまったので調べてみたところ、最小限のヘッダは以下のようです。
````
% cat -n /tmp/1
     1  From: =?ISO-2022-JP?Q?LOCOLET_=28=1B=24B=25=22=25=26=25H=25l=25C=25H=1B=28B=29?= <no-reply@locondo.jp>
     2  Subject: =?UTF-8?Q?=E3=80=90SEVEN_TWELVE_THIRTY=E3=80=81CO?=
     3   =?UTF-8?Q?LE_HAAN=E3=81=AA=E3=81=A9=E3=80=91=E7=89=B9=E5=88=A5?=
     4   =?UTF-8?Q?=E3=82=A2=E3=82=A6=E3=83=88=E3=83=AC=E3=83=83=E3=83=88?=
     5   =?UTF-8?Q?=E3=81=8C=E3=82=B9=E3=82=BF=E3=83=BC=E3=83=88=EF=BC=81?=
     6
% ./bsfilter-orig.rb --verbose /tmp/1
start 2024-07-31 23:58:08 +0900
open /home/koie/.bsfilter/C.prob.sdbm 41726 tokens 41726 mails by 90984.
open /home/koie/.bsfilter/ja.prob.sdbm 64319 tokens 64319 mails by 90984.
./bsfilter-orig.rb:1258:in `gsub': invalid byte sequence in EUC-JP (ArgumentError)

        content = NKF.nkf('-e -X -Z0', content.gsub(/\?(iso-2202-jp|shift-jis)\?/i, '?ISO-2022-JP?'))
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        from ./bsfilter-orig.rb:1258:in `block in tokenize_headers'
        from ./bsfilter-orig.rb:1240:in `each'
        from ./bsfilter-orig.rb:1240:in `tokenize_headers'
        from ./bsfilter-orig.rb:1301:in `tokenize_buf'
        from ./bsfilter-orig.rb:3415:in `block (2 levels) in run'
        from ./bsfilter-orig.rb:319:in `open_ro'
        from ./bsfilter-orig.rb:3411:in `block in run'
        from ./bsfilter-orig.rb:3410:in `each'
        from ./bsfilter-orig.rb:3410:in `run'
        from ./bsfilter-orig.rb:3465:in `<main>'
````

よくわかってないですが、文字列をきれいにしたらエラーが起こらなくなりました。
````
% diff -u bsfilter-orig.rb bsfilter.rb
--- bsfilter-orig.rb    2024-07-31 23:53:01.048934000 +0900
+++ bsfilter.rb 2024-07-31 23:53:24.028970000 +0900
@@ -1255,6 +1255,7 @@
             ''
           end
         end
+        content = NKF.nkf('-e -X -Z0 -m0', content);
         content = NKF.nkf('-e -X -Z0', content.gsub(/\?(iso-2202-jp|shift-jis)\?/i, '?ISO-2022-JP?'))
       else
         content = latin2ascii(content)
% ./bsfilter.rb --verbose /tmp/1
start 2024-07-31 23:58:14 +0900
open /home/koie/.bsfilter/C.prob.sdbm 41726 tokens 41726 mails by 91000.
open /home/koie/.bsfilter/ja.prob.sdbm 64319 tokens 64319 mails by 91000.
combined probability /tmp/1 1 0.000000
close /home/koie/.bsfilter/C.prob.sdbm 41726 tokens 41726 mails by 91000.
close /home/koie/.bsfilter/ja.prob.sdbm 64319 tokens 64319 mails by 91000.
end 2024-07-31 23:58:14 +0900
````